### PR TITLE
fix typo (lowercase the "e" in "Validation errors")

### DIFF
--- a/constants/invalidAttributes.exit.js
+++ b/constants/invalidAttributes.exit.js
@@ -1,6 +1,6 @@
 module.exports = {
   description: 'One or more of the provided attributes were invalid.',
-  outputFriendlyName: 'Validation Errors',
+  outputFriendlyName: 'Validation errors',
   outputDescription: 'An array of validation errors.',
   outputExample: [{}]
 };


### PR DESCRIPTION
@sgress454 this just normalizes the lower-case-ness of the outputFriendlyName
